### PR TITLE
Update broken link in README.md

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -47,7 +47,7 @@ Come and say hi! on our [Github discussion](https://github.com/microcks/microcks
 
 Wondering where to start first?
 
-> **⏩ Very easy and straightforward using [Docker Desktop Extension](https://microcks.io/documentation/installing/docker-desktop-extension/)**
+> **⏩ Very easy and straightforward using [Docker Desktop Extension](https://microcks.io/documentation/guides/installation/docker-desktop-extension/)**
 
 But don't forget to check all the [documentation](https://microcks.io/documentation/) we are maintaining:  
 - [Quickstart](https://microcks.io/documentation/getting-started/) 👍


### PR DESCRIPTION
### Description

- Docker desktop extension link broken.

Broken Link:
https://microcks.io/documentation/installing/docker-desktop-extension/

Updated Link:
https://microcks.io/documentation/guides/installation/docker-desktop-extension/ 