### PR TITLE
chore: update CNCF status from Sandbox to Incubating

### DIFF
--- a/BACKERS.md
+++ b/BACKERS.md
@@ -1,6 +1,6 @@
 # Sponsors &amp; Backers
 
-[Microcks](https://microcks.io/) is a [Cloud Native Computing Foundation Sandbox](https://landscape.cncf.io/?selected=microcks) project 🚀 with its ongoing development made possible entirely by the support of the awesome sponsors and backers listed in this file. If you'd like to join them, please consider [sponsoring](https://opencollective.com/microcks) Microcks's development.
+[Microcks](https://microcks.io/) is a [Cloud Native Computing Foundation Incubating](https://landscape.cncf.io/?item=app-definition-and-development--application-definition-image-build--microcks) project 🚀 with its ongoing development made possible entirely by the support of the awesome sponsors and backers listed in this file. If you'd like to join them, please consider [sponsoring](https://opencollective.com/microcks) Microcks's development.
 
 **BTW 📢 _If you're using Microcks in your organization, please add your company name to the adopters list. 🙏 It really helps the project to gain momentum and credibility. It's a small contribution back to the project with a big impact._**
 https://github.com/microcks/.github/blob/main/ADOPTERS.md

--- a/profile/README.md
+++ b/profile/README.md
@@ -13,7 +13,7 @@
 ## ✨ Welcome to Microcks,
 
 The open source, cloud native tool for API Mocking and Testing.
-[Microcks](https://microcks.io/) is a [Cloud Native Computing Foundation Sandbox](https://landscape.cncf.io/card-mode?selected=microcks) project 🚀
+[Microcks](https://microcks.io/) is a [Cloud Native Computing Foundation Incubating](https://landscape.cncf.io/?item=app-definition-and-development--application-definition-image-build--microcks) project 🚀
 
 As numerous API styles and protocols coexist, there is a need for a uniform way to accelerate and secure their delivery! Our objective is to establish Microcks as the de-facto standard tool for delivering this unified approach [the open source way](https://www.theopensourceway.org/) 🙌
 


### PR DESCRIPTION
## Summary

Microcks has been promoted to **CNCF Incubating** ([CNCF project page](https://www.cncf.io/projects/microcks/)). Updating the two places that still reference the Sandbox tier:

- [`profile/README.md`](profile/README.md) — the org-level landing page
- [`BACKERS.md`](BACKERS.md)

Two-line diff, label text changed from `Cloud Native Computing Foundation Sandbox` to `Cloud Native Computing Foundation Incubating`. Links continue to point at the CNCF Landscape entry for consistency with the existing pattern in `microcks/microcks/README.md`.

`ADOPTERS.md` mentions of "sandbox" are users' own environments using Microcks, not CNCF status — left untouched.

## Test plan

- [x] Visual inspection of rendered markdown
- [x] No other references to "Sandbox" tied to CNCF status across the repo